### PR TITLE
solver: specify pointer in g_critical call

### DIFF
--- a/src/emeus-simplex-solver.c
+++ b/src/emeus-simplex-solver.c
@@ -231,7 +231,7 @@ simplex_solver_init (SimplexSolver *solver)
 {
   if (solver->initialized)
     {
-      g_critical ("The SimplexSolver %p has already been initialized");
+      g_critical ("The SimplexSolver %p has already been initialized", solver);
       return;
     }
 


### PR DESCRIPTION
Fix an annoying warning when compiling with ninja.