### PR TITLE
examples: show ConstraintLayoutChild

### DIFF
--- a/examples/simple-grid.js
+++ b/examples/simple-grid.js
@@ -6,6 +6,7 @@ Emeus.ConstraintLayout.prototype.pack = function(child, name=null, constraints=[
     let layout_child = new Emeus.ConstraintLayoutChild({ name: name });
     layout_child.add(child);
     this.add(layout_child);
+    layout_child.show();
 
     constraints.forEach(layout_child.add_constraint, layout_child);
 };


### PR DESCRIPTION
Without calling show on the ConstraintLayoutChild
this example won't display any of the buttons.