### PR TITLE
layout: just remove child widget

### DIFF
--- a/src/emeus-constraint-layout.c
+++ b/src/emeus-constraint-layout.c
@@ -807,6 +807,7 @@ emeus_constraint_layout_remove (GtkContainer *container,
 
   was_visible = gtk_widget_get_visible (GTK_WIDGET (layout_child));
 
+  gtk_container_remove (GTK_CONTAINER (layout_child), child);
   gtk_widget_unparent (GTK_WIDGET (layout_child));
   g_sequence_remove (layout_child->iter);
 


### PR DESCRIPTION
There are cases where we want to remove a widget, and add
it back later. Make sure to don't destroy the child widget
and just remove it.