### PR TITLE
layout: expect to remove empty child

### DIFF
--- a/src/emeus-constraint-layout.c
+++ b/src/emeus-constraint-layout.c
@@ -732,9 +732,7 @@ remove_constraints_from_widget (GHashTable *constraints,
   GHashTableIter iter;
   gpointer key;
 
-  g_return_if_fail (GTK_IS_WIDGET (widget));
-
-  if (constraints == NULL)
+  if (constraints == NULL || widget == NULL)
     return;
 
   g_hash_table_iter_init (&iter, constraints);


### PR DESCRIPTION
It is possible that the layout child has no a widget added to
it, so don't make that assumption when removing constraints.