### PR TITLE
tools: Fix launcher in EndlessOS

### DIFF
--- a/src/tools/com.endlessm.EmeusEditor.desktop.in.in
+++ b/src/tools/com.endlessm.EmeusEditor.desktop.in.in
@@ -2,7 +2,6 @@
 Name=Emeus Editor
 Comment=Editor for Emeus constraints
 Exec=emeus-edit-constraints
-DBusActivatable=true
 StartupNotify=true
 Terminal=false
 Type=Application


### PR DESCRIPTION
Honestly, I don't understand why this is happening,
but the launcher simply won't work. You see "Emeus
Editor" among search results, but clicking on it
has no effect. No error can be seen in the journal.

Removing DBusActivatable makes the launcher work.