### PR TITLE
Be more careful with goto

### DIFF
--- a/src/emeus-simplex-solver.c
+++ b/src/emeus-simplex-solver.c
@@ -645,10 +645,11 @@ simplex_solver_remove_column (SimplexSolver *solver,
                               Variable *variable)
 {
   VariableSet *set = g_hash_table_lookup (solver->columns, variable);
-  if (set == NULL)
-    goto out;
 
   variable_ref (variable);
+
+  if (set == NULL)
+    goto out;
 
   VariableSetIter iter;
   Variable *v;


### PR DESCRIPTION
This goto was jumping over a ref without skipping the
corresponding unref. Sadly, fixing this does not make
the segfault go away yet.