### PR TITLE
Add the 'obvious' constraints

### DIFF
--- a/src/emeus-constraint-layout.c
+++ b/src/emeus-constraint-layout.c
@@ -343,6 +343,18 @@ get_layout_attribute (EmeusConstraintLayout   *layout,
       }
       break;
 
+    case EMEUS_CONSTRAINT_ATTRIBUTE_WIDTH:
+    case EMEUS_CONSTRAINT_ATTRIBUTE_HEIGHT:
+      {
+        Expression *expr = expression_new_from_constant (0.0);
+        simplex_solver_add_constraint (&layout->solver,
+                                       res, OPERATOR_TYPE_GE, expr,
+                                       STRENGTH_REQUIRED);
+
+        expression_unref (expr);
+      }
+      break;
+
     default:
       break;
     }
@@ -453,6 +465,18 @@ get_child_attribute (EmeusConstraintLayoutChild *child,
           simplex_solver_add_constraint (child->solver,
                                          res, OPERATOR_TYPE_EQ, expr,
                                          STRENGTH_REQUIRED);
+
+        expression_unref (expr);
+      }
+      break;
+
+    case EMEUS_CONSTRAINT_ATTRIBUTE_WIDTH:
+    case EMEUS_CONSTRAINT_ATTRIBUTE_HEIGHT:
+      {
+        Expression *expr = expression_new_from_constant (0.0);
+        simplex_solver_add_constraint (child->solver,
+                                       res, OPERATOR_TYPE_GE, expr,
+                                       STRENGTH_REQUIRED);
 
         expression_unref (expr);
       }


### PR DESCRIPTION
Add the 'obvious' constraints

width >= 0
height >= 0

for all widget sizes. This avoids 'solutions'
involving negative sizes, which GTK+ does not
like at all.