### PR TITLE
Meson: remove pos argument from i18n.merge_file

### DIFF
--- a/src/tools/meson.build
+++ b/src/tools/meson.build
@@ -5,8 +5,7 @@ gen_constraints = executable('emeus-gen-constraints', 'emeus-gen-constraints.c',
                              install: true)
 
 # Desktop launcher and description file.
-i18n.merge_file('desktop',
-                input: 'com.endlessm.EmeusEditor.desktop.in',
+i18n.merge_file(input: 'com.endlessm.EmeusEditor.desktop.in',
                 output: 'com.endlessm.EmeusEditor.desktop',
                 install: true,
                 install_dir: join_paths(emeus_datadir, 'applications'),


### PR DESCRIPTION
Fixes https://github.com/wingtk/gvsbuild/issues/789.

Previously, i18n.merge_file was ignoring positional arguments, and it causes an Error since meson 0.60.0.

See https://github.com/mesonbuild/meson/issues/9441.